### PR TITLE
Supplier ownership

### DIFF
--- a/codegen/src/main/java/com/mattworzala/canary/codegen/genspec/assertion/AssertionGenerator.java
+++ b/codegen/src/main/java/com/mattworzala/canary/codegen/genspec/assertion/AssertionGenerator.java
@@ -219,8 +219,8 @@ public class AssertionGenerator extends RecursiveElementVisitor<TypeSpec.Builder
     // public static boolean ...(Operator actual, ...)
     private static boolean isValidCondition(ExecutableElement element) {
         //todo check first parameter type
+        //todo check return type
         return element.getParameters().size() >= 1 &&
-                element.getReturnType().getKind() == TypeKind.BOOLEAN &&
                 element.getModifiers().contains(Modifier.PUBLIC) &&
                 element.getModifiers().contains(Modifier.STATIC);
     }

--- a/src/main/java/com/mattworzala/canary/internal/assertion/AeSimpleParser.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/AeSimpleParser.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 public class AeSimpleParser {
     /** Contains the steps originally provided to the parser */
@@ -47,7 +48,11 @@ public class AeSimpleParser {
     private AeNode parseCondition(@NotNull AssertionStep step) {
         assert step.type() == AssertionStep.Type.AND;
         assert step.condition() != null;
-        return new AeConditionNode(step.condition());
+        return new AeConditionNode(
+                Objects.requireNonNull(step.debugName()),
+                Objects.requireNonNull(step.supplier()),
+                Objects.requireNonNull(step.condition())
+        );
     }
 
     @NotNull
@@ -97,21 +102,5 @@ public class AeSimpleParser {
             throw new RuntimeException("A unary node must be followed by a condition node.");
         }
         return List.of(item);
-    }
-
-    public static void main(String[] args) {
-        List<AssertionStep> steps = new ArrayList<>();
-        steps.add(AssertionStep.NOT);
-        steps.add(new AssertionStep(AssertionStep.Type.CONDITION, new AssertionCondition("a", null)));
-        steps.add(AssertionStep.AND);
-        steps.add(new AssertionStep(AssertionStep.Type.CONDITION, new AssertionCondition("b", null)));
-//        steps.add(AssertionStep.AND);
-//        steps.add(AssertionStep.NOT);
-//        steps.add(new AssertionStep(AssertionStep.Type.CONDITION, "c"));
-
-        var parser = new AeSimpleParser(steps);
-        System.out.println(parser.parse());
-
-
     }
 }

--- a/src/main/java/com/mattworzala/canary/internal/assertion/AssertionStep.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/AssertionStep.java
@@ -1,17 +1,22 @@
 package com.mattworzala.canary.internal.assertion;
 
+import com.mattworzala.canary.api.supplier.ObjectSupplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public record AssertionStep(@NotNull Type type, @Nullable AssertionCondition condition) {
+import java.util.function.Predicate;
+
+public record AssertionStep(
+        @NotNull Type type,
+        @Nullable String debugName,
+        @Nullable ObjectSupplier supplier,
+        @Nullable Result.Predicate<Object> condition) {
+
     // Control flow words
-    public static final AssertionStep AND = new AssertionStep(Type.AND, null);
-
-    public static final AssertionStep NOT = new AssertionStep(Type.NOT, null);
-
-    public static final AssertionStep ALWAYS = new AssertionStep(Type.ALWAYS, null);
-
-    public static final AssertionStep THEN = new AssertionStep(Type.THEN, null);
+    public static final AssertionStep AND = new AssertionStep(Type.AND, null, null, null);
+    public static final AssertionStep NOT = new AssertionStep(Type.NOT, null, null, null);
+    public static final AssertionStep ALWAYS = new AssertionStep(Type.ALWAYS, null, null, null);
+    public static final AssertionStep THEN = new AssertionStep(Type.THEN, null, null, null);
 
     public enum Type {
         CONDITION,

--- a/src/main/java/com/mattworzala/canary/internal/assertion/ManualTest.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/ManualTest.java
@@ -3,23 +3,40 @@ package com.mattworzala.canary.internal.assertion;
 import com.mattworzala.canary.api.Assertions;
 import com.mattworzala.canary.api.supplier.ObjectSupplier;
 import com.mattworzala.canary.internal.assertion.node.AeNode;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class ManualTest {
     public static void main(String[] args) {
-        ObjectSupplier sup = () -> "abc";
+        ObjectSupplier sup = () -> {
+            Entity entity = new Entity(EntityType.ZOMBIE);
+            return entity;
+        };
 
         List<AssertionStep> steps = new ArrayList<>();
 
-        new Assertions.Assertion(sup, steps)
-                .toEqual("abc");
+        new Assertions.EntityAssertion(sup, steps)
+                .toBeAt(new Vec(0, 0, 0))
+                .and()
+                .toBeAt(new Vec(1, 1, 1));
 
         AeNode root = new AeSimpleParser(steps).parse();
 
         System.out.println(root);
-        System.out.println(root.evaluate(sup.get()) == Result.PASS);
+
+        Result result = root.evaluate(null);
+        System.out.println("PASS : " + result.isPass());
+        System.out.println("SOFT_PASS : " + result.isSoftPass());
+        System.out.println("FAIL : " + result.isFail());
+
+        System.out.println();
+        if (result instanceof Result.FailResult failure) {
+            failure.printToStdout(true);
+        }
 
     }
 }

--- a/src/main/java/com/mattworzala/canary/internal/assertion/Result.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/Result.java
@@ -1,7 +1,117 @@
 package com.mattworzala.canary.internal.assertion;
 
-public enum Result {
-    PASS,
-    FAIL,
-    SOFT_PASS,
+import net.minestom.server.coordinate.Point;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public sealed abstract class Result permits Result.PassResult, Result.FailResult {
+
+    @FunctionalInterface
+    public interface Predicate<T> {
+        Result test(T t);
+    }
+
+
+    public static Result Pass() {
+        return PassResult.HARD;
+    }
+
+    public static Result SoftPass() {
+        return PassResult.SOFT;
+    }
+
+
+    public static FailResult Fail(String reason) {
+        return Fail(reason, null);
+    }
+
+    public static FailResult Fail(String reason, Result cause) {
+        return new FailResult(reason, cause);
+    }
+
+
+
+
+
+
+
+    
+    public boolean isPass() { return false; }
+    public boolean isFail() { return false; }
+    public boolean isSoftPass() { return false; }
+
+
+    @Nullable
+    public Result getCause() {
+        return null;
+    }
+
+
+
+    // TODO : Implement #equals
+
+
+
+
+
+    public static final class PassResult extends Result {
+        private static final Result SOFT = new PassResult(true);
+        private static final Result HARD = new PassResult(false);
+
+        private final boolean soft;
+
+        private PassResult(boolean soft) {
+            this.soft = soft;
+        }
+
+        @Override
+        public boolean isPass() {
+            return !soft;
+        }
+
+        @Override
+        public boolean isSoftPass() {
+            return soft;
+        }
+    }
+
+    public static final class FailResult extends Result {
+        private final String reason;
+
+        private final Result cause;
+
+        public FailResult(String reason, Result cause) {
+            this.reason = reason;
+            this.cause = cause;
+        }
+
+        @NotNull
+        public String getReason() {
+            return reason;
+        }
+
+
+        @Override
+        public @Nullable Result getCause() {
+            return cause;
+        }
+
+        @Override
+        public boolean isFail() {
+            return true;
+        }
+
+        public FailResult withMarker(Point location, int color, String message) {
+            // TODO : Implement
+            return this;
+        }
+
+        public void printToStdout(boolean first) {
+            System.out.println((first ? "" : "> ") + getReason());
+
+            if (getCause() instanceof FailResult failCause) {
+                failCause.printToStdout(false);
+            }
+        }
+    }
 }

--- a/src/main/java/com/mattworzala/canary/internal/assertion/impl/AssertionBase.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/impl/AssertionBase.java
@@ -3,6 +3,8 @@ package com.mattworzala.canary.internal.assertion.impl;
 import com.mattworzala.canary.api.supplier.ObjectSupplier;
 import com.mattworzala.canary.internal.assertion.AssertionCondition;
 import com.mattworzala.canary.internal.assertion.AssertionStep;
+import com.mattworzala.canary.internal.assertion.Result;
+import com.mattworzala.canary.internal.assertion.spec.EntityAssertionSpec;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -16,7 +18,12 @@ public class AssertionBase<T, This extends AssertionBase<T, This>> {
         this.steps = steps;
     }
 
-    protected void appendCondition(String debugName, Predicate<T> condition) {
-        steps.add(new AssertionStep(AssertionStep.Type.CONDITION, new AssertionCondition(debugName, (o) -> condition.test((T) o))));
+    protected void appendCondition(String debugName, Result.Predicate<T> condition) {
+        steps.add(new AssertionStep(AssertionStep.Type.CONDITION, debugName, supplier, (o) -> condition.test((T) o)));
+    }
+
+    public This and() {
+        steps.add(AssertionStep.AND);
+        return (This) this;
     }
 }

--- a/src/main/java/com/mattworzala/canary/internal/assertion/node/AeAlwaysNode.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/node/AeAlwaysNode.java
@@ -15,7 +15,7 @@ public class AeAlwaysNode extends AeNode.Unary {
     //todo docs explaining why we cache only a failed result
     @Override
     protected @NotNull Result test(Object target) {
-        if (cache == null || cache != Result.FAIL) {
+        if (cache == null || cache.isFail()) {
             cache = sample(target);
         }
         return cache;
@@ -24,9 +24,9 @@ public class AeAlwaysNode extends AeNode.Unary {
     @Override
     public @NotNull Result sample(Object target) {
         Result proxy = item().evaluate(target);
-        if (proxy == Result.FAIL)
-            return Result.FAIL;
-        return Result.SOFT_PASS;
+        if (proxy.isFail())
+            return Result.Fail("TODO : Not Implemented", proxy);
+        return Result.SoftPass();
     }
 
     @Override

--- a/src/main/java/com/mattworzala/canary/internal/assertion/node/AeAlwaysNode.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/node/AeAlwaysNode.java
@@ -15,7 +15,7 @@ public class AeAlwaysNode extends AeNode.Unary {
     //todo docs explaining why we cache only a failed result
     @Override
     protected @NotNull Result test(Object target) {
-        if (cache == null || cache.isFail()) {
+        if (cache == null || !cache.isFail()) {
             cache = sample(target);
         }
         return cache;

--- a/src/main/java/com/mattworzala/canary/internal/assertion/node/AeAndNode.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/node/AeAndNode.java
@@ -13,11 +13,15 @@ public class AeAndNode extends AeNode.Binary {
     @Override
     protected @NotNull Result test(Object target) {
         Result left = lhs().evaluate(target), right = rhs().evaluate(target);
-        if (left == Result.FAIL || right == Result.FAIL)
-            return Result.FAIL;
-        if (left == Result.SOFT_PASS || right == Result.SOFT_PASS)
-            return Result.SOFT_PASS;
-        return Result.PASS;
+        // Handle LHS/RHS failure individually for better reporting
+        if (left.isFail())
+            return Result.Fail("Expected left side to pass, but it failed", left);
+        if (right.isFail())
+            return Result.Fail("Expected right side to pass, but it failed", right);
+
+        if (left.isSoftPass() || right.isSoftPass())
+            return Result.SoftPass();
+        return Result.Pass();
     }
 
     @Override

--- a/src/main/java/com/mattworzala/canary/internal/assertion/node/AeConditionNode.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/node/AeConditionNode.java
@@ -1,19 +1,23 @@
 package com.mattworzala.canary.internal.assertion.node;
 
+import com.mattworzala.canary.api.supplier.ObjectSupplier;
 import com.mattworzala.canary.internal.assertion.AssertionCondition;
 import com.mattworzala.canary.internal.assertion.Result;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 public class AeConditionNode extends AeNode {
-    private final AssertionCondition condition;
+    private final String debugName;
+    private final ObjectSupplier supplier;
+    private final Predicate<Object> test;
 
     public AeConditionNode(@NotNull AssertionCondition condition) {
         super(List.of());
 
-        this.condition = condition;
+        this.debugName = condition.debugName();
     }
 
     @Override

--- a/src/main/java/com/mattworzala/canary/internal/assertion/node/AeConditionNode.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/node/AeConditionNode.java
@@ -1,7 +1,6 @@
 package com.mattworzala.canary.internal.assertion.node;
 
 import com.mattworzala.canary.api.supplier.ObjectSupplier;
-import com.mattworzala.canary.internal.assertion.AssertionCondition;
 import com.mattworzala.canary.internal.assertion.Result;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,30 +11,31 @@ import java.util.function.Predicate;
 public class AeConditionNode extends AeNode {
     private final String debugName;
     private final ObjectSupplier supplier;
-    private final Predicate<Object> test;
+    private final Result.Predicate<Object> condition;
 
-    public AeConditionNode(@NotNull AssertionCondition condition) {
+    public AeConditionNode(@NotNull String debugName, @NotNull ObjectSupplier supplier, @NotNull Result.Predicate<Object> condition) {
         super(List.of());
-
-        this.debugName = condition.debugName();
+        this.debugName = debugName;
+        this.supplier = supplier;
+        this.condition = condition;
     }
+
 
     @Override
     protected @NotNull Result test(Object target) {
         //todo this does not work, we need more information from the test itself.
         //     Specifically error messages are not possible this way, it will need to be supplied by the assertion itself.
-        var predicate = Objects.requireNonNull(condition.test());
 
         try {
-            return predicate.test(target) ? Result.PASS : Result.FAIL;
+            return condition.test(supplier.get());
         } catch (Throwable throwable) {
-            //todo failure should result in message with exception
-            return Result.FAIL;
+            //todo Should be able to render the stacktrace, not just the message.
+            return Result.Fail(throwable.getMessage());
         }
     }
 
     @Override
     public String toString() {
-        return condition.debugName();
+        return debugName;
     }
 }

--- a/src/main/java/com/mattworzala/canary/internal/assertion/node/AeNode.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/node/AeNode.java
@@ -28,6 +28,7 @@ public abstract class AeNode {
         return history.stream();
     }
 
+    // TODO : Remove `target` parameter, it is never used.
     @NotNull
     public final Result evaluate(Object target) {
         Result result = test(target);

--- a/src/main/java/com/mattworzala/canary/internal/assertion/node/AeNotNode.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/node/AeNotNode.java
@@ -13,9 +13,9 @@ public class AeNotNode extends AeNode.Unary {
     @Override
     protected @NotNull Result test(Object target) {
         Result result = item().evaluate(target);
-        if (result == Result.FAIL)
-            return Result.PASS;
-        return Result.FAIL;
+        if (result.isFail())
+            return Result.Pass();
+        return Result.Fail("TODO : Not Implemented");
     }
 
     @Override

--- a/src/main/java/com/mattworzala/canary/internal/assertion/node/AeThenNode.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/node/AeThenNode.java
@@ -19,11 +19,11 @@ public class AeThenNode extends AeNode.Binary {
             return rhs().test(target);
         }
         Result left = lhs().evaluate(target);
-        if (left == Result.PASS) {
+        if (left.isPass()) {
             testingRight = true;
             return rhs().test(target);
         }
-        return Result.FAIL;
+        return Result.Fail("TODO : Not Implemented");
     }
 
     @Override

--- a/src/main/java/com/mattworzala/canary/internal/assertion/spec/AssertionSpec.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/spec/AssertionSpec.java
@@ -1,5 +1,7 @@
 package com.mattworzala.canary.internal.assertion.spec;
 
+import com.mattworzala.canary.internal.assertion.Result;
+
 import static com.mattworzala.canary.internal.assertion.spec.GenSpec.*;
 
 @GenSpec(operator = Object.class, supertype = "")
@@ -25,8 +27,10 @@ public class AssertionSpec {
          */
 
     @Condition("value=\"{0}\"")
-    public static boolean toEqual(Object actual, Object expected) {
-        return expected.equals(actual);
+    public static Result toEqual(Object actual, Object expected) {
+        if (expected.equals(actual))
+            return Result.Pass();
+        return Result.Fail("TODO : Not Implemented");
     }
 
     @Doc("""
@@ -34,8 +38,10 @@ public class AssertionSpec {
             Note: {@link #toEqual} may be used to {@link Object#equals(Object)} equality.
             """)
     @Condition("value=\"{0}\"")
-    public static boolean toEqualStrict(Object actual, @Doc("The expected value") Object expected) {
-        return expected == actual;
+    public static Result toEqualStrict(Object actual, @Doc("The expected value") Object expected) {
+        if (expected == actual)
+            return Result.Pass();
+        return Result.Fail("TODO : Not Implemented");
     }
 
 }

--- a/src/main/java/com/mattworzala/canary/internal/assertion/spec/BlockAssertionSpec.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/spec/BlockAssertionSpec.java
@@ -1,5 +1,6 @@
 package com.mattworzala.canary.internal.assertion.spec;
 
+import com.mattworzala.canary.internal.assertion.Result;
 import net.minestom.server.instance.block.Block;
 
 import static com.mattworzala.canary.internal.assertion.spec.GenSpec.*;
@@ -9,8 +10,10 @@ import static com.mattworzala.canary.internal.assertion.spec.GenSpec.*;
 public class BlockAssertionSpec {
 
     @Condition
-    public static boolean toHaveProperty(Block actual, String property, String value) {
-        return value.equals(actual.getProperty(property));
+    public static Result toHaveProperty(Block actual, String property, String value) {
+        if (value.equals(actual.getProperty(property)))
+            return Result.Pass();
+        return Result.Fail("TODO : Not Implemented");
     }
 
 }

--- a/src/main/java/com/mattworzala/canary/internal/assertion/spec/EntityAssertionSpec.java
+++ b/src/main/java/com/mattworzala/canary/internal/assertion/spec/EntityAssertionSpec.java
@@ -1,16 +1,18 @@
 package com.mattworzala.canary.internal.assertion.spec;
 
 import com.mattworzala.canary.api.supplier.PointSupplier;
+import com.mattworzala.canary.internal.assertion.Result;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.instance.Instance;
 
-import static com.mattworzala.canary.internal.assertion.spec.GenSpec.Condition;
+import static com.mattworzala.canary.internal.assertion.spec.GenSpec.*;
 
 @GenSpec(operator = Entity.class, supertype = "Assertion")
 public class EntityAssertionSpec {
 
-    // TODO : Allow @Doc on transitions    @Transition
+    // TODO : Allow @Doc on transitions
+    @Transition
     public static Instance instance(Entity entity) {
         return entity.getInstance();
     }
@@ -24,23 +26,27 @@ public class EntityAssertionSpec {
 //        return actual.getPosition().sameBlock(expected);
 //    }
 
-    @Condition
-    public static boolean toBeAt(Entity actual, Point expected) {
-//        context.createErrorHandler((handler) -> {
-//            handler.addMarker(expected, 0xFF0000, "Not Reached!");
-//            return "Expected " + actual.getUuid() + " to reach " + expected;
-//        } /* implicit capture of `actual` and `expected` */);
-        return actual.getPosition().sameBlock(expected);
+    @Condition("entity@{0}")
+    public static Result toBeAt(Entity actual, Point expected) {
+        if (actual.getPosition().sameBlock(expected)) {
+            return Result.Pass();
+        }
+        return Result.Fail("Expected " + actual.getUuid() + " to reach " + expected)
+                .withMarker(expected, 0xFF0000, "Not Reached!");
     }
 
     @Condition
-    public static boolean toBeAt(Entity actual, PointSupplier expected) {
-        return actual.getPosition().sameBlock(expected.get());
+    public static Result toBeAt(Entity actual, PointSupplier expected) {
+        if (actual.getPosition().sameBlock(expected.get()))
+            return Result.Pass();
+        return Result.Fail("TODO : Not Implemented");
     }
 
     @Condition
-    public static boolean toBeAtStrict(Entity actual, Point expected) {
-        return actual.getPosition().samePoint(expected);
+    public static Result toBeAtStrict(Entity actual, Point expected) {
+        if (actual.getPosition().samePoint(expected))
+            return Result.Pass();
+        return Result.Fail("TODO : Not Implemented");
     }
 
 

--- a/src/test/java/com/mattworzala/canary/internal/assertion/Helper.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/Helper.java
@@ -1,0 +1,27 @@
+package com.mattworzala.canary.internal.assertion;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Helper {
+
+    public static void assertPass(Result actual) {
+        assertTrue(actual.isPass(), "expected PASS, was " + (actual.isFail() ? "FAIL" : "SOFT_PASS"));
+    }
+
+    public static void assertSoftPass(Result actual) {
+        assertTrue(actual.isSoftPass(), "expected SOFT_PASS, was " + (actual.isFail() ? "FAIL" : "PASS"));
+    }
+
+    public static void assertFail(Result actual) {
+        assertTrue(actual.isFail(), "expected FAIL, was " + (actual.isPass() ? "PASS" : "SOFT_PASS"));
+    }
+
+    /**
+     * Ensures the two values have the same value, without comparing details such as reason or cause for failures.
+     */
+    public static void assertSameResult(Result expected, Result actual) {
+        assertTrue((expected.isPass() && actual.isPass()) ||
+                (expected.isSoftPass() && actual.isSoftPass()) ||
+                (expected.isFail() && actual.isFail()));
+    }
+}

--- a/src/test/java/com/mattworzala/canary/internal/assertion/ResultTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/ResultTest.java
@@ -1,0 +1,38 @@
+package com.mattworzala.canary.internal.assertion;
+
+import org.junit.jupiter.api.Test;
+
+import static com.mattworzala.canary.internal.assertion.node.AeTestNode.RES_FAIL;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ResultTest {
+
+    // This test is to highlight when this behavior is changed, not test any particular correctness.
+    @Test
+    public void testResultImplementationDetail() {
+        assertSame(Result.Pass(), Result.Pass());
+        assertSame(Result.SoftPass(), Result.SoftPass());
+
+        assertNotSame(Result.Fail("reason"), Result.Fail("reason"));
+    }
+
+    @Test
+    public void testFailEqualsAndHashCode() {
+        // Same reason
+        assertEquals(Result.Fail("reason"), Result.Fail("reason"));
+        assertEquals(Result.Fail("reason").hashCode(), Result.Fail("reason").hashCode());
+        assertNotSame(Result.Fail("reason"), Result.Fail("reason"));
+
+        // Different reason
+        assertNotEquals(Result.Fail("reason"), Result.Fail("other reason"));
+
+        // Same reason & cause
+        assertEquals(Result.Fail("reason", RES_FAIL), Result.Fail("reason", RES_FAIL));
+        assertEquals(Result.Fail("reason", RES_FAIL).hashCode(), Result.Fail("reason", RES_FAIL).hashCode());
+        assertNotSame(Result.Fail("reason", RES_FAIL), Result.Fail("reason", RES_FAIL));
+
+        // Different cause
+        assertNotEquals(Result.Fail("reason", RES_FAIL), Result.Fail("reason", Result.Fail("another reason")));
+        assertNotEquals(Result.Fail("reason", RES_FAIL).hashCode(), Result.Fail("reason", Result.Fail("another reason")).hashCode());
+    }
+}

--- a/src/test/java/com/mattworzala/canary/internal/assertion/impl/AssertionBaseTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/impl/AssertionBaseTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.mattworzala.canary.internal.assertion.node.AeTestNode.RES_PASS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AssertionBaseTest {
@@ -15,7 +16,7 @@ public class AssertionBaseTest {
         List<AssertionStep> steps = new ArrayList<>();
         AssertionBase impl = new AssertionBase(null, steps);
 
-        impl.appendCondition("test", o -> true);
+        impl.appendCondition("test", o -> RES_PASS);
 
         assertEquals(1, steps.size());
 

--- a/src/test/java/com/mattworzala/canary/internal/assertion/impl/AssertionBaseTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/impl/AssertionBaseTest.java
@@ -21,6 +21,6 @@ public class AssertionBaseTest {
 
         AssertionStep created = steps.get(0);
         assertEquals(AssertionStep.Type.CONDITION, created.type());
-        assertEquals("test", created.condition().debugName());
+        assertEquals("test", created.debugName());
     }
 }

--- a/src/test/java/com/mattworzala/canary/internal/assertion/node/AeAndNodeTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/node/AeAndNodeTest.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.mattworzala.canary.internal.assertion.Helper.assertPass;
+import static com.mattworzala.canary.internal.assertion.Helper.assertSameResult;
 import static com.mattworzala.canary.internal.assertion.node.AeTestNode.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,17 +20,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class AeAndNodeTest {
     private static Stream<Arguments> providePossibleResults() {
         return Stream.of(
-                Arguments.of(PASS, PASS, Result.PASS),
-                Arguments.of(PASS, SOFT_PASS, Result.SOFT_PASS),
-                Arguments.of(PASS, FAIL, Result.FAIL),
+                Arguments.of(NODE_PASS, NODE_PASS, RES_PASS),
+                Arguments.of(NODE_PASS, NODE_SOFT_PASS, RES_SOFT_PASS),
+                Arguments.of(NODE_PASS, NODE_FAIL, RES_FAIL),
 
-                Arguments.of(SOFT_PASS, PASS, Result.SOFT_PASS),
-                Arguments.of(SOFT_PASS, SOFT_PASS, Result.SOFT_PASS),
-                Arguments.of(SOFT_PASS, FAIL, Result.FAIL),
+                Arguments.of(NODE_SOFT_PASS, NODE_PASS, RES_SOFT_PASS),
+                Arguments.of(NODE_SOFT_PASS, NODE_SOFT_PASS, RES_SOFT_PASS),
+                Arguments.of(NODE_SOFT_PASS, NODE_FAIL, RES_FAIL),
 
-                Arguments.of(FAIL, PASS, Result.FAIL),
-                Arguments.of(FAIL, SOFT_PASS, Result.FAIL),
-                Arguments.of(FAIL, FAIL, Result.FAIL)
+                Arguments.of(NODE_FAIL, NODE_PASS, RES_FAIL),
+                Arguments.of(NODE_FAIL, NODE_SOFT_PASS, RES_FAIL),
+                Arguments.of(NODE_FAIL, NODE_FAIL, RES_FAIL)
         );
     }
 
@@ -37,7 +39,7 @@ public class AeAndNodeTest {
     public void testResultCombinations(AeNode lhs, AeNode rhs, Result expected) {
         AeAndNode node = new AeAndNode(List.of(lhs, rhs));
 
-        assertEquals(expected, node.evaluate(null));
+        assertSameResult(expected, node.evaluate(null));
     }
 
     // Non-standard child count
@@ -45,23 +47,23 @@ public class AeAndNodeTest {
     @ParameterizedTest
     @ValueSource(ints = {0, 1})
     public void testMissingChildShouldFailToEvaluate(int count) {
-        AeAndNode node = new AeAndNode(Collections.nCopies(count, PASS));
+        AeAndNode node = new AeAndNode(Collections.nCopies(count, NODE_PASS));
 
         assertThrows(IllegalStateException.class, () -> node.evaluate(null));
     }
 
     @Test
     public void testExtraChildrenShouldBeIgnored() {
-        AeAndNode node = new AeAndNode(List.of(PASS, PASS, PASS));
+        AeAndNode node = new AeAndNode(List.of(NODE_PASS, NODE_PASS, NODE_PASS));
 
-        assertEquals(Result.PASS, node.evaluate(null));
+        assertPass(node.evaluate(null));
     }
 
     // toString
 
     @Test
     public void testToString() {
-        AeAndNode node = new AeAndNode(List.of(PASS, PASS));
+        AeAndNode node = new AeAndNode(List.of(NODE_PASS, NODE_PASS));
 
         assertEquals("(<test> AND <test>)", node.toString());
     }

--- a/src/test/java/com/mattworzala/canary/internal/assertion/node/AeConditionNodeTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/node/AeConditionNodeTest.java
@@ -1,36 +1,35 @@
 package com.mattworzala.canary.internal.assertion.node;
 
-import com.mattworzala.canary.internal.assertion.AssertionCondition;
-import com.mattworzala.canary.internal.assertion.Result;
-import com.mattworzala.canary.internal.assertion.node.AeConditionNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static com.mattworzala.canary.internal.assertion.Helper.assertFail;
+import static com.mattworzala.canary.internal.assertion.Helper.assertPass;
+import static com.mattworzala.canary.internal.assertion.node.AeTestNode.RES_FAIL;
+import static com.mattworzala.canary.internal.assertion.node.AeTestNode.RES_PASS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AeConditionNodeTest {
 
     @Test
     public void testPassingConditionShouldPass() {
-        AeConditionNode node = new AeConditionNode("test", () -> null, o -> true);
+        AeConditionNode node = new AeConditionNode("test", () -> null, o -> RES_PASS);
 
-        Assertions.assertEquals(Result.PASS, node.evaluate(null));
+        assertPass(node.evaluate(null));
     }
 
     @Test
     public void testFailingConditionShouldFail() {
-        AssertionCondition assertionCondition = new AssertionCondition("test", o -> false);
-        AeConditionNode node = new AeConditionNode("test", () -> null, o -> false);
+        AeConditionNode node = new AeConditionNode("test", () -> null, o -> RES_FAIL);
 
-        assertEquals(Result.FAIL, node.evaluate(null));
+        assertFail(node.evaluate(null));
     }
 
     @Test
     public void testTargetShouldBeForwardedToPredicate() {
-        AeConditionNode node = new AeConditionNode("test", () -> true, o -> (boolean) o);
+        AeConditionNode node = new AeConditionNode("test", () -> true, o -> (boolean) o ? RES_PASS : RES_FAIL);
 
-        assertEquals(Result.PASS, node.evaluate(true));
+        assertPass(node.evaluate(true));
     }
 
     // Condition problems
@@ -41,7 +40,7 @@ public class AeConditionNodeTest {
             throw new RuntimeException("Failure expected");
         });
 
-        assertEquals(Result.FAIL, node.evaluate(null));
+        assertFail(node.evaluate(null));
     }
 
     // toString

--- a/src/test/java/com/mattworzala/canary/internal/assertion/node/AeConditionNodeTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/node/AeConditionNodeTest.java
@@ -13,8 +13,7 @@ public class AeConditionNodeTest {
 
     @Test
     public void testPassingConditionShouldPass() {
-        AssertionCondition assertionCondition = new AssertionCondition("test", o -> true);
-        AeConditionNode node = new AeConditionNode(assertionCondition);
+        AeConditionNode node = new AeConditionNode("test", () -> null, o -> true);
 
         Assertions.assertEquals(Result.PASS, node.evaluate(null));
     }
@@ -22,15 +21,14 @@ public class AeConditionNodeTest {
     @Test
     public void testFailingConditionShouldFail() {
         AssertionCondition assertionCondition = new AssertionCondition("test", o -> false);
-        AeConditionNode node = new AeConditionNode(assertionCondition);
+        AeConditionNode node = new AeConditionNode("test", () -> null, o -> false);
 
         assertEquals(Result.FAIL, node.evaluate(null));
     }
 
     @Test
     public void testTargetShouldBeForwardedToPredicate() {
-        AssertionCondition assertionCondition = new AssertionCondition("test", o -> (boolean) o);
-        AeConditionNode node = new AeConditionNode(assertionCondition);
+        AeConditionNode node = new AeConditionNode("test", () -> true, o -> (boolean) o);
 
         assertEquals(Result.PASS, node.evaluate(true));
     }
@@ -39,31 +37,20 @@ public class AeConditionNodeTest {
 
     @Test
     public void testExceptionInConditionShouldFail() {
-        AssertionCondition assertionCondition = new AssertionCondition("test", o -> {
+        AeConditionNode node = new AeConditionNode("test", () -> null, o -> {
             throw new RuntimeException("Failure expected");
         });
 
-        AeConditionNode node = new AeConditionNode(assertionCondition);
-
         assertEquals(Result.FAIL, node.evaluate(null));
-    }
-
-    @Test
-    public void testNullConditionShouldThrow() {
-        AssertionCondition assertionCondition = new AssertionCondition("test", null);
-
-        AeConditionNode node = new AeConditionNode(assertionCondition);
-        //todo should this exception occur when constructing the node? probably.
-        //     potentially AssertionCondition#condition could just be @NotNull
-
-        assertThrows(NullPointerException.class, () -> node.evaluate(null));
     }
 
     // toString
 
     @Test
     public void testToString() {
-        AeConditionNode node = new AeConditionNode(new AssertionCondition("test", o -> { throw new IllegalStateException("Should not evaluate assertion for toString"); }));
+        AeConditionNode node = new AeConditionNode("test", () -> null, o -> {
+            throw new IllegalStateException("Should not evaluate assertion for toString");
+        });
 
         assertEquals("test", node.toString());
     }

--- a/src/test/java/com/mattworzala/canary/internal/assertion/node/AeNodeTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/node/AeNodeTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Collections;
 
-import static com.mattworzala.canary.internal.assertion.node.AeTestNode.PASS;
+import static com.mattworzala.canary.internal.assertion.Helper.assertPass;
+import static com.mattworzala.canary.internal.assertion.node.AeTestNode.NODE_PASS;
+import static com.mattworzala.canary.internal.assertion.node.AeTestNode.RES_PASS;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class AeNodeTest {
@@ -16,14 +18,14 @@ public class AeNodeTest {
 
     @Test
     public void testEvaluateShouldReturnSampleResult() {
-        AeNode node = new AeTestNode(Result.PASS);
+        AeNode node = new AeTestNode(RES_PASS);
 
-        assertEquals(Result.PASS, node.evaluate(null));
+        assertPass(node.evaluate(null));
     }
 
     @Test
     public void testEvaluateShouldAddToHistory() {
-        AeNode node = new AeTestNode(Result.PASS);
+        AeNode node = new AeTestNode(RES_PASS);
 
         // Start at 0
         assertEquals(0, node.history().count());
@@ -35,14 +37,14 @@ public class AeNodeTest {
         assertEquals(2, node.history().count());
 
         // Should now contain only PASS values
-        assertTrue(node.history().allMatch(result -> result == Result.PASS));
+        assertTrue(node.history().allMatch(result -> result == RES_PASS));
     }
 
     // sample
 
     @Test
     public void testSampleShouldNotModifyHistory() {
-        AeNode node = new AeTestNode(Result.PASS);
+        AeNode node = new AeTestNode(RES_PASS);
 
         // Start at 0
         assertEquals(0, node.history().count());
@@ -59,17 +61,17 @@ public class AeNodeTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 3})
     public void testGetChildShouldWorkWithOneOrMoreChildren(int count) {
-        AeNode node = new AeTestNode(Collections.nCopies(count, PASS));
+        AeNode node = new AeTestNode(Collections.nCopies(count, NODE_PASS));
 
         for (int i = 0; i < count; i++) {
-            assertEquals(PASS, node.getChild(i));
+            assertEquals(NODE_PASS, node.getChild(i));
         }
     }
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1})
     public void testGetChildShouldDefaultToMissing(int count) {
-        AeNode node = new AeTestNode(Collections.nCopies(count, PASS));
+        AeNode node = new AeTestNode(Collections.nCopies(count, NODE_PASS));
 
         assertEquals(AeNode.MISSING, node.getChild(-1));
         assertEquals(AeNode.MISSING, node.getChild(count));

--- a/src/test/java/com/mattworzala/canary/internal/assertion/node/AeNotNodeTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/node/AeNotNodeTest.java
@@ -9,17 +9,19 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.mattworzala.canary.internal.assertion.Helper.assertFail;
+import static com.mattworzala.canary.internal.assertion.Helper.assertSameResult;
 import static com.mattworzala.canary.internal.assertion.node.AeTestNode.*;
-import static com.mattworzala.canary.internal.assertion.node.AeTestNode.FAIL;
+import static com.mattworzala.canary.internal.assertion.node.AeTestNode.NODE_FAIL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AeNotNodeTest {
     private static Stream<Arguments> providePossibleResults() {
         return Stream.of(
-                Arguments.of(PASS, Result.FAIL),
-                Arguments.of(SOFT_PASS, Result.FAIL), //todo is this correct?
-                Arguments.of(FAIL, Result.PASS)
+                Arguments.of(NODE_PASS, RES_FAIL),
+                Arguments.of(NODE_SOFT_PASS, RES_FAIL), //todo is this correct?
+                Arguments.of(NODE_FAIL, RES_PASS)
         );
     }
 
@@ -28,7 +30,7 @@ public class AeNotNodeTest {
     public void testResultCombinations(AeNode item, Result expected) {
         AeNotNode node = new AeNotNode(List.of(item));
 
-        assertEquals(expected, node.evaluate(null));
+        assertSameResult(expected, node.evaluate(null));
     }
 
     // Non-standard child count
@@ -42,16 +44,16 @@ public class AeNotNodeTest {
 
     @Test
     public void testExtraChildrenShouldBeIgnored() {
-        AeNotNode node = new AeNotNode(List.of(PASS, PASS));
+        AeNotNode node = new AeNotNode(List.of(NODE_PASS, NODE_PASS));
 
-        assertEquals(Result.FAIL, node.evaluate(null));
+        assertFail(node.evaluate(null));
     }
 
     // toString
 
     @Test
     public void testToString() {
-        AeNotNode node = new AeNotNode(List.of(FAIL));
+        AeNotNode node = new AeNotNode(List.of(NODE_FAIL));
 
         assertEquals("(NOT <test>)", node.toString());
     }

--- a/src/test/java/com/mattworzala/canary/internal/assertion/node/AeTestNode.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/node/AeTestNode.java
@@ -6,9 +6,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class AeTestNode extends AeNode {
-    public static final AeTestNode PASS = new AeTestNode(Result.PASS);
+    public static final AeTestNode PASS = new AeTestNode(Result.Pass());
     public static final AeTestNode FAIL = new AeTestNode(Result.FAIL);
-    public static final AeTestNode SOFT_PASS = new AeTestNode(Result.SOFT_PASS);
+    public static final AeTestNode SOFT_PASS = new AeTestNode(Result.SoftPass());
 
     public Result result = Result.FAIL;
 

--- a/src/test/java/com/mattworzala/canary/internal/assertion/node/AeTestNode.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/node/AeTestNode.java
@@ -6,11 +6,15 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class AeTestNode extends AeNode {
-    public static final AeTestNode PASS = new AeTestNode(Result.Pass());
-    public static final AeTestNode FAIL = new AeTestNode(Result.FAIL);
-    public static final AeTestNode SOFT_PASS = new AeTestNode(Result.SoftPass());
+    public static final Result RES_PASS = Result.Pass();
+    public static final Result RES_SOFT_PASS = Result.SoftPass();
+    public static final Result RES_FAIL = Result.Fail("checked");
 
-    public Result result = Result.FAIL;
+    public static final AeTestNode NODE_PASS = new AeTestNode(Result.Pass());
+    public static final AeTestNode NODE_FAIL = new AeTestNode(RES_FAIL);
+    public static final AeTestNode NODE_SOFT_PASS = new AeTestNode(Result.SoftPass());
+
+    public Result result = RES_FAIL;
 
     public AeTestNode(Result result) {
         super(List.of());

--- a/src/test/java/com/mattworzala/canary/internal/assertion/spec/AssertionSpecTest.java
+++ b/src/test/java/com/mattworzala/canary/internal/assertion/spec/AssertionSpecTest.java
@@ -2,27 +2,26 @@ package com.mattworzala.canary.internal.assertion.spec;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.mattworzala.canary.internal.assertion.Helper.*;
 import static com.mattworzala.canary.internal.assertion.spec.AssertionSpec.*;
 
 public class AssertionSpecTest {
 
     @Test
     public void testToEqualShouldUseEqualsFunction() {
-        assertTrue(toEqual(1, 1));
-        assertTrue(toEqual("123", "123"));
+        assertPass(toEqual(1, 1));
+        assertPass(toEqual("123", "123"));
 
-        assertFalse(toEqual("123", "456"));
+        assertFail(toEqual("123", "456"));
     }
 
     @Test
     public void testToEqualStrictShouldUseReferentialEquality() {
-        assertTrue(toEqualStrict(1, 1));
+        assertPass(toEqualStrict(1, 1));
         String myString = "123";
-        assertTrue(toEqualStrict(myString, myString));
+        assertPass(toEqualStrict(myString, myString));
 
-        assertFalse(toEqualStrict("123", "456"));
-        assertFalse(toEqualStrict(new String("123"), new String("123")));
+        assertFail(toEqualStrict("123", "456"));
+        assertFail(toEqualStrict(new String("123"), new String("123")));
     }
 }


### PR DESCRIPTION
Moves supplier ownership to the `AeConditionNode`, meaning the `TestExecutor` no longer needs to pay attention to them.

The downside of this change is that we execute the suppliers more often, but it reduces a lot of complexity.